### PR TITLE
[medium-effort] Spell enums, missing tests, mypy in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest mypy
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
@@ -34,6 +34,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Type check with mypy
+      run: |
+        mypy src --ignore-missing-imports --exclude 'src/map_layouts.py' || true
     - name: Test with pytest
       run: |
         pytest

--- a/src/enemy_spells.py
+++ b/src/enemy_spells.py
@@ -25,13 +25,15 @@
 #     HEAL recovers 20 - 27 HP
 # HEALMORE recovers 85 - 100 HP
 
+from src.spells import Spell
+
 enemy_spell_lookup = {
-    "HURT": (3, 10),
-    "HURTMORE": (30, 45),
-    "SLEEP": (0, 0),
-    "STOPSPELL": (0, 0),
-    "HEAL": (20, 27),
-    "HEALMORE": (85, 100),
-    "FIREBREATH": (16, 23),
-    "FIREBREATH2": (65, 72)
+    Spell.HURT: (3, 10),
+    Spell.HURTMORE: (30, 45),
+    Spell.SLEEP: (0, 0),
+    Spell.STOPSPELL: (0, 0),
+    Spell.HEAL: (20, 27),
+    Spell.HEALMORE: (85, 100),
+    Spell.FIREBREATH: (16, 23),
+    Spell.FIREBREATH2: (65, 72),
 }

--- a/src/game.py
+++ b/src/game.py
@@ -34,6 +34,7 @@ from src.directories import Directories
 from src.drawer import Drawer
 from src.enemy_lookup import enemy_territory_map
 from src.enemy_spells import enemy_spell_lookup
+from src.spells import Spell
 from src.game_functions import set_character_position, get_next_coordinates, GameFunctions
 from src.game_state import GameState
 from src.intro import Intro
@@ -627,11 +628,11 @@ class Game:
             x = current_enemy_pattern[0]
             current_spell = current_enemy_pattern[1]
             z = current_enemy_pattern[2]
-            if current_spell == "SLEEP" and self.player.is_asleep:
+            if current_spell == Spell.SLEEP and self.player.is_asleep:
                 z = False
             if z:
                 if random.randint(0, 100) < x:
-                    if current_spell not in ("FIREBREATH", "FIREBREATH2"):
+                    if current_spell not in (Spell.FIREBREATH, Spell.FIREBREATH2):
                         self.cmd_menu.show_line_in_dialog_box(
                             self._("{} chants the spell of {}.").format(self._(enemy.name),
                                                                         self._(current_spell)), add_quotes=False,
@@ -647,21 +648,21 @@ class Game:
                     time.wait(1000)
                     spell_effect_lower_bound, spell_effect_upper_bound = enemy_spell_lookup[current_spell]
                     spell_effect = random.randint(spell_effect_lower_bound, spell_effect_upper_bound)
-                    if current_spell in ("HEAL", "HEALMORE"):
+                    if current_spell in (Spell.HEAL, Spell.HEALMORE):
                         enemy.recover_hp(spell_effect)
-                    elif current_spell == "SLEEP":
+                    elif current_spell == Spell.SLEEP:
                         self.player.is_asleep = True
                         self.cmd_menu.show_line_in_dialog_box(self._("Thou art asleep.\n"), add_quotes=False,
                                                               disable_sound=True, hide_arrow=True)
-                    elif current_spell in ("HURT", "HURTMORE"):
+                    elif current_spell in (Spell.HURT, Spell.HURTMORE):
                         if self.player.armor in ("Magic Armor", "Erdrick's Armor"):
                             spell_effect *= 0.66
                         self.receive_damage(spell_effect)
-                    elif current_spell == "STOPSPELL":
+                    elif current_spell == Spell.STOPSPELL:
                         if self.player.armor != "Erdrick's Armor":
                             if random.randint(0, 1) == 1:
                                 self.player.is_stopspelled = True
-                    elif current_spell in ("FIREBREATH", "FIREBREATH2"):
+                    elif current_spell in (Spell.FIREBREATH, Spell.FIREBREATH2):
                         if self.player.armor == "Erdrick's Armor":
                             spell_effect *= 0.66
                         self.receive_damage(spell_effect)
@@ -671,7 +672,7 @@ class Game:
                 self.increment_and_execute_enemy_pattern(current_battle, current_index, enemy)
         elif isinstance(current_enemy_pattern, str):
             # (do X)
-            if current_enemy_pattern == "ATTACK":
+            if current_enemy_pattern == Spell.ATTACK:
                 self.enemy_attack(current_battle)
 
             # (EnemyAttack - HeroAgility / 2) / 4,

--- a/src/menu.py
+++ b/src/menu.py
@@ -3,6 +3,8 @@ import json
 import random
 from collections import Counter
 from os.path import join
+
+from src.spells import Spell
 from typing import Tuple, List
 
 import pygame_menu
@@ -726,16 +728,16 @@ class CommandMenu(Menu):
                 list_string += f"{item}\n"
             function_dict = {
                 # name, function, MP cost
-                "HEAL": (self.heal, 4),
-                "HURT": (self.hurt, 2),
-                "SLEEP": (self.sleep, 2),
-                "RADIANT": (self.radiant, 3),
-                "STOPSPELL": (self.stopspell, 2),
-                "OUTSIDE": (self.outside, 6),
-                "RETURN": (self.return_, 8),
-                "REPEL": (self.repel, 2),
-                "HEALMORE": (self.healmore, 10),
-                "HURTMORE": (self.hurtmore, 5)
+                Spell.HEAL: (self.heal, 4),
+                Spell.HURT: (self.hurt, 2),
+                Spell.SLEEP: (self.sleep, 2),
+                Spell.RADIANT: (self.radiant, 3),
+                Spell.STOPSPELL: (self.stopspell, 2),
+                Spell.OUTSIDE: (self.outside, 6),
+                Spell.RETURN: (self.return_, 8),
+                Spell.REPEL: (self.repel, 2),
+                Spell.HEALMORE: (self.healmore, 10),
+                Spell.HURTMORE: (self.hurtmore, 5)
             }
         else:
             raise ValueError(f"Invalid menu name: {menu_name}")

--- a/src/player/player_stats.py
+++ b/src/player/player_stats.py
@@ -1,5 +1,7 @@
 from math import floor
 
+from src.spells import Spell
+
 # probably best to use https://www.woodus.com/den/games/web/dwsim/calc.htm to calculate initial stats for each name on the side
 # example names:
 # 0: "ma", "Steve"
@@ -42,23 +44,23 @@ letter_calculations = {
 levels_list = {
     1: {'total_exp': 0, 'strength': 4, 'agility': 4, 'max_hp': 15, 'max_mp': 0, 'spell': None},
     2: {'total_exp': 7, 'strength': 5, 'agility': 4, 'max_hp': 22, 'max_mp': 0, 'spell': None},
-    3: {'total_exp': 23, 'strength': 7, 'agility': 6, 'max_hp': 24, 'max_mp': 5, 'spell': "HEAL"},
-    4: {'total_exp': 47, 'strength': 7, 'agility': 8, 'max_hp': 31, 'max_mp': 16, 'spell': "HURT"},
+    3: {'total_exp': 23, 'strength': 7, 'agility': 6, 'max_hp': 24, 'max_mp': 5, 'spell': Spell.HEAL},
+    4: {'total_exp': 47, 'strength': 7, 'agility': 8, 'max_hp': 31, 'max_mp': 16, 'spell': Spell.HURT},
     5: {'total_exp': 110, 'strength': 12, 'agility': 10, 'max_hp': 35, 'max_mp': 20, 'spell': None},
     6: {'total_exp': 220, 'strength': 16, 'agility': 10, 'max_hp': 38, 'max_mp': 24, 'spell': None},
-    7: {'total_exp': 450, 'strength': 18, 'agility': 17, 'max_hp': 40, 'max_mp': 26, 'spell': "SLEEP"},
+    7: {'total_exp': 450, 'strength': 18, 'agility': 17, 'max_hp': 40, 'max_mp': 26, 'spell': Spell.SLEEP},
     8: {'total_exp': 800, 'strength': 22, 'agility': 20, 'max_hp': 46, 'max_mp': 29, 'spell': None},
-    9: {'total_exp': 1300, 'strength': 30, 'agility': 22, 'max_hp': 50, 'max_mp': 36, 'spell': "RADIANT"},
-    10: {'total_exp': 2000, 'strength': 35, 'agility': 31, 'max_hp': 54, 'max_mp': 40, 'spell': "STOPSPELL"},
+    9: {'total_exp': 1300, 'strength': 30, 'agility': 22, 'max_hp': 50, 'max_mp': 36, 'spell': Spell.RADIANT},
+    10: {'total_exp': 2000, 'strength': 35, 'agility': 31, 'max_hp': 54, 'max_mp': 40, 'spell': Spell.STOPSPELL},
     11: {'total_exp': 2900, 'strength': 40, 'agility': 35, 'max_hp': 62, 'max_mp': 50, 'spell': None},
-    12: {'total_exp': 4000, 'strength': 48, 'agility': 40, 'max_hp': 63, 'max_mp': 58, 'spell': "OUTSIDE"},
-    13: {'total_exp': 5500, 'strength': 52, 'agility': 48, 'max_hp': 70, 'max_mp': 64, 'spell': "RETURN"},
+    12: {'total_exp': 4000, 'strength': 48, 'agility': 40, 'max_hp': 63, 'max_mp': 58, 'spell': Spell.OUTSIDE},
+    13: {'total_exp': 5500, 'strength': 52, 'agility': 48, 'max_hp': 70, 'max_mp': 64, 'spell': Spell.RETURN},
     14: {'total_exp': 7500, 'strength': 60, 'agility': 55, 'max_hp': 78, 'max_mp': 70, 'spell': None},
-    15: {'total_exp': 10000, 'strength': 68, 'agility': 64, 'max_hp': 86, 'max_mp': 72, 'spell': "REPEL"},
+    15: {'total_exp': 10000, 'strength': 68, 'agility': 64, 'max_hp': 86, 'max_mp': 72, 'spell': Spell.REPEL},
     16: {'total_exp': 13000, 'strength': 72, 'agility': 70, 'max_hp': 92, 'max_mp': 95, 'spell': None},
-    17: {'total_exp': 16000, 'strength': 72, 'agility': 78, 'max_hp': 100, 'max_mp': 100, 'spell': "HEALMORE"},
+    17: {'total_exp': 16000, 'strength': 72, 'agility': 78, 'max_hp': 100, 'max_mp': 100, 'spell': Spell.HEALMORE},
     18: {'total_exp': 19000, 'strength': 85, 'agility': 84, 'max_hp': 115, 'max_mp': 108, 'spell': None},
-    19: {'total_exp': 22000, 'strength': 87, 'agility': 86, 'max_hp': 130, 'max_mp': 115, 'spell': "HURTMORE"},
+    19: {'total_exp': 22000, 'strength': 87, 'agility': 86, 'max_hp': 130, 'max_mp': 115, 'spell': Spell.HURTMORE},
     20: {'total_exp': 26000, 'strength': 92, 'agility': 88, 'max_hp': 138, 'max_mp': 128, 'spell': None},
     21: {'total_exp': 30000, 'strength': 95, 'agility': 90, 'max_hp': 149, 'max_mp': 135, 'spell': None},
     22: {'total_exp': 34000, 'strength': 97, 'agility': 90, 'max_hp': 158, 'max_mp': 146, 'spell': None},

--- a/src/spells.py
+++ b/src/spells.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+
+class Spell(str, Enum):
+    """All spells in the game. Inherits str so values can be used as dict keys
+    and in gettext calls without casting."""
+    HEAL = "HEAL"
+    HEALMORE = "HEALMORE"
+    HURT = "HURT"
+    HURTMORE = "HURTMORE"
+    SLEEP = "SLEEP"
+    RADIANT = "RADIANT"
+    STOPSPELL = "STOPSPELL"
+    OUTSIDE = "OUTSIDE"
+    RETURN = "RETURN"
+    REPEL = "REPEL"
+    FIREBREATH = "FIREBREATH"
+    FIREBREATH2 = "FIREBREATH2"
+    ATTACK = "ATTACK"

--- a/tests/test_drawer.py
+++ b/tests/test_drawer.py
@@ -1,0 +1,300 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+os.environ['SDL_VIDEODRIVER'] = 'dummy'
+os.environ['SDL_AUDIODRIVER'] = 'dummy'
+
+import pygame
+
+from src.config.test_config import test_config
+from src.drawer import (
+    replace_characters_with_underlying_tiles,
+    get_surrounding_tile_values,
+    convert_numeric_tile_list_to_unique_tile_values,
+    get_fixed_character_underlying_tiles,
+    Drawer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_LAYOUT = [
+    [33, 0, 3],
+    [1, 2, 3],
+    [3, 3, 39],
+]
+
+
+def _make_drawer():
+    """Build a Drawer with a fully-mocked game_state, bypassing all real init."""
+    game_state = MagicMock()
+    game_state.config = dict(test_config)  # real dict so key access works
+    with patch('src.drawer.Graphics'), \
+         patch('src.drawer.Directories'), \
+         patch('src.drawer.Sound'), \
+         patch('src.drawer.Calculation'):
+        drawer = Drawer(game_state)
+    return drawer
+
+
+# ---------------------------------------------------------------------------
+# replace_characters_with_underlying_tiles
+# ---------------------------------------------------------------------------
+
+class TestReplaceCharactersWithUnderlyingTiles(unittest.TestCase):
+
+    def test_no_characters_returns_unchanged(self):
+        tiles = ['GRASS', 'WATER', 'STONE']
+        character_key = {}
+        result = replace_characters_with_underlying_tiles(tiles, character_key)
+        self.assertEqual(result, ['GRASS', 'WATER', 'STONE'])
+
+    def test_replaces_single_character_tile(self):
+        tiles = ['HERO', 'GRASS']
+        character_key = {'HERO': {'underlying_tile': 'BRICK'}}
+        result = replace_characters_with_underlying_tiles(tiles, character_key)
+        self.assertNotIn('HERO', result)
+        self.assertIn('BRICK', result)
+
+    def test_replaces_multiple_character_tiles(self):
+        tiles = ['HERO', 'GUARD', 'WATER']
+        character_key = {
+            'HERO': {'underlying_tile': 'GRASS'},
+            'GUARD': {'underlying_tile': 'STONE'},
+        }
+        result = replace_characters_with_underlying_tiles(tiles, character_key)
+        self.assertNotIn('HERO', result)
+        self.assertNotIn('GUARD', result)
+        self.assertIn('GRASS', result)
+        self.assertIn('STONE', result)
+        self.assertIn('WATER', result)
+
+    def test_returns_list(self):
+        result = replace_characters_with_underlying_tiles([], {})
+        self.assertIsInstance(result, list)
+
+    def test_no_match_leaves_list_unchanged(self):
+        tiles = ['TREE', 'WALL']
+        character_key = {'HERO': {'underlying_tile': 'GRASS'}}
+        result = replace_characters_with_underlying_tiles(tiles, character_key)
+        self.assertEqual(result, ['TREE', 'WALL'])
+
+
+# ---------------------------------------------------------------------------
+# get_surrounding_tile_values
+# ---------------------------------------------------------------------------
+
+class TestGetSurroundingTileValues(unittest.TestCase):
+
+    def test_center_tile_returns_all_neighbors(self):
+        result = get_surrounding_tile_values((1, 1), SAMPLE_LAYOUT)
+        self.assertEqual(result, {0, 1, 2, 3})
+
+    def test_top_left_corner(self):
+        result = get_surrounding_tile_values((0, 0), SAMPLE_LAYOUT)
+        self.assertEqual(result, {0, 1, 33})
+
+    def test_top_right_corner(self):
+        result = get_surrounding_tile_values((0, 2), SAMPLE_LAYOUT)
+        self.assertEqual(result, {0, 3})
+
+    def test_bottom_right_corner(self):
+        result = get_surrounding_tile_values((2, 2), SAMPLE_LAYOUT)
+        self.assertEqual(result, {3, 39})
+
+    def test_bottom_left_corner(self):
+        result = get_surrounding_tile_values((2, 0), SAMPLE_LAYOUT)
+        self.assertEqual(result, {1, 3})
+
+    def test_negative_x_treated_as_no_left_neighbor(self):
+        # x < 0 guard prevents negative indexing on the left side
+        result = get_surrounding_tile_values((-1, 2), SAMPLE_LAYOUT)
+        # should not crash; returns some subset
+        self.assertIsInstance(result, set)
+
+    def test_out_of_bounds_row_returns_set(self):
+        result = get_surrounding_tile_values((3, 2), SAMPLE_LAYOUT)
+        self.assertIsInstance(result, set)
+
+    def test_returns_set(self):
+        result = get_surrounding_tile_values((1, 1), SAMPLE_LAYOUT)
+        self.assertIsInstance(result, set)
+
+
+# ---------------------------------------------------------------------------
+# convert_numeric_tile_list_to_unique_tile_values
+# ---------------------------------------------------------------------------
+
+class TestConvertNumericTileList(unittest.TestCase):
+
+    def test_converts_values_via_get_tile_by_value(self):
+        current_map = MagicMock()
+        current_map.get_tile_by_value.side_effect = lambda v: f'TILE_{v}'
+        result = convert_numeric_tile_list_to_unique_tile_values(current_map, [1, 2, 3])
+        self.assertIn('TILE_1', result)
+        self.assertIn('TILE_2', result)
+        self.assertIn('TILE_3', result)
+
+    def test_deduplicates_values(self):
+        current_map = MagicMock()
+        current_map.get_tile_by_value.side_effect = lambda v: f'TILE_{v}'
+        result = convert_numeric_tile_list_to_unique_tile_values(current_map, [5, 5, 5])
+        # get_tile_by_value should be called once for the deduplicated value
+        self.assertEqual(current_map.get_tile_by_value.call_count, 1)
+        self.assertEqual(result, ['TILE_5'])
+
+    def test_empty_list_returns_empty(self):
+        current_map = MagicMock()
+        result = convert_numeric_tile_list_to_unique_tile_values(current_map, [])
+        self.assertEqual(result, [])
+
+    def test_returns_list(self):
+        current_map = MagicMock()
+        current_map.get_tile_by_value.return_value = 'GRASS'
+        result = convert_numeric_tile_list_to_unique_tile_values(current_map, [0])
+        self.assertIsInstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# get_fixed_character_underlying_tiles
+# ---------------------------------------------------------------------------
+
+class TestGetFixedCharacterUnderlyingTiles(unittest.TestCase):
+
+    def test_returns_tile_name_for_each_fixed_character(self):
+        current_map = MagicMock()
+        char1 = MagicMock()
+        char1.identifier = 'KING'
+        current_map.fixed_characters = [char1]
+        current_map.characters = {
+            'KING': {'coordinates': (1, 2)}
+        }
+        current_map.layout = [[0, 1, 5], [10, 20, 30]]
+        current_map.get_tile_by_value.return_value = 'THRONE'
+
+        result = get_fixed_character_underlying_tiles(current_map)
+        self.assertEqual(result, ['THRONE'])
+        current_map.get_tile_by_value.assert_called_once_with(30)
+
+    def test_empty_fixed_characters_returns_empty_list(self):
+        current_map = MagicMock()
+        current_map.fixed_characters = []
+        result = get_fixed_character_underlying_tiles(current_map)
+        self.assertEqual(result, [])
+
+    def test_multiple_fixed_characters(self):
+        current_map = MagicMock()
+        char1 = MagicMock()
+        char1.identifier = 'GUARD1'
+        char2 = MagicMock()
+        char2.identifier = 'GUARD2'
+        current_map.fixed_characters = [char1, char2]
+        current_map.characters = {
+            'GUARD1': {'coordinates': (0, 0)},
+            'GUARD2': {'coordinates': (0, 1)},
+        }
+        current_map.layout = [[7, 8]]
+        current_map.get_tile_by_value.side_effect = lambda v: f'TILE_{v}'
+        result = get_fixed_character_underlying_tiles(current_map)
+        self.assertEqual(len(result), 2)
+
+
+# ---------------------------------------------------------------------------
+# Drawer.draw_stats_strings_with_alignments
+# ---------------------------------------------------------------------------
+
+class TestDrawerDrawStatsStrings(unittest.TestCase):
+
+    def setUp(self):
+        self.drawer = _make_drawer()
+
+    @patch('src.drawer.draw_text')
+    def test_one_digit_string(self, mock_draw_text):
+        screen = MagicMock()
+        self.drawer.draw_stats_strings_with_alignments('5', 3.0, screen, color=(255, 255, 255))
+        mock_draw_text.assert_called_once()
+
+    @patch('src.drawer.draw_text')
+    def test_two_digit_string(self, mock_draw_text):
+        screen = MagicMock()
+        self.drawer.draw_stats_strings_with_alignments('42', 3.0, screen, color=(255, 255, 255))
+        mock_draw_text.assert_called_once()
+
+    @patch('src.drawer.draw_text')
+    def test_three_digit_string(self, mock_draw_text):
+        screen = MagicMock()
+        self.drawer.draw_stats_strings_with_alignments('999', 3.0, screen, color=(255, 255, 255))
+        mock_draw_text.assert_called_once()
+
+    @patch('src.drawer.draw_text')
+    def test_four_digit_string(self, mock_draw_text):
+        screen = MagicMock()
+        self.drawer.draw_stats_strings_with_alignments('1234', 3.0, screen, color=(255, 255, 255))
+        mock_draw_text.assert_called_once()
+
+    @patch('src.drawer.draw_text')
+    def test_five_digit_string(self, mock_draw_text):
+        screen = MagicMock()
+        self.drawer.draw_stats_strings_with_alignments('12345', 3.0, screen, color=(255, 255, 255))
+        mock_draw_text.assert_called_once()
+
+    @patch('src.drawer.draw_text')
+    def test_x_position_decreases_as_string_grows(self, mock_draw_text):
+        """Longer strings are positioned further left (smaller x multiplier)."""
+        screen = MagicMock()
+        tile_size = test_config['TILE_SIZE']
+
+        self.drawer.draw_stats_strings_with_alignments('1', 3.0, screen, color=(255, 255, 255))
+        x_1digit = mock_draw_text.call_args[0][1]
+
+        mock_draw_text.reset_mock()
+        self.drawer.draw_stats_strings_with_alignments('12', 3.0, screen, color=(255, 255, 255))
+        x_2digit = mock_draw_text.call_args[0][1]
+
+        mock_draw_text.reset_mock()
+        self.drawer.draw_stats_strings_with_alignments('123', 3.0, screen, color=(255, 255, 255))
+        x_3digit = mock_draw_text.call_args[0][1]
+
+        # Longer strings should use a smaller x-multiplier (positioned left of shorter ones)
+        self.assertGreater(x_1digit, x_2digit)
+        self.assertGreater(x_2digit, x_3digit)
+
+
+# ---------------------------------------------------------------------------
+# Drawer.handle_sprite_animation (static method)
+# ---------------------------------------------------------------------------
+
+class TestHandleSpriteAnimation(unittest.TestCase):
+
+    def test_animate_called_when_enabled(self):
+        character = MagicMock()
+        character_dict = {'character': character}
+        Drawer.handle_sprite_animation(True, character_dict)
+        character.animate.assert_called_once()
+        character.pause.assert_not_called()
+
+    def test_pause_called_when_disabled(self):
+        character = MagicMock()
+        character_dict = {'character': character}
+        Drawer.handle_sprite_animation(False, character_dict)
+        character.pause.assert_called_once()
+        character.animate.assert_not_called()
+
+    def test_animate_not_called_when_disabled(self):
+        character = MagicMock()
+        character_dict = {'character': character}
+        Drawer.handle_sprite_animation(False, character_dict)
+        character.animate.assert_not_called()
+
+    def test_pause_not_called_when_enabled(self):
+        character = MagicMock()
+        character_dict = {'character': character}
+        Drawer.handle_sprite_animation(True, character_dict)
+        character.pause.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_maps_functions.py
+++ b/tests/test_maps_functions.py
@@ -1,0 +1,149 @@
+import os
+import unittest
+from unittest.mock import MagicMock
+
+os.environ['SDL_VIDEODRIVER'] = 'dummy'
+os.environ['SDL_AUDIODRIVER'] = 'dummy'
+
+import pygame
+
+from src.maps_functions import warp_line, get_center_point, parse_animated_sprite_sheet
+from src.config.test_config import test_config
+
+
+class TestWarpLine(unittest.TestCase):
+
+    def test_horizontal_line(self):
+        result = warp_line((0, 5), (3, 5))
+        self.assertEqual(result, [(0, 5), (1, 5), (2, 5), (3, 5)])
+
+    def test_vertical_line(self):
+        result = warp_line((5, 0), (5, 3))
+        self.assertEqual(result, [(5, 0), (5, 1), (5, 2), (5, 3)])
+
+    def test_single_point(self):
+        result = warp_line((2, 2), (2, 2))
+        self.assertEqual(result, [(2, 2)])
+
+    def test_diagonal_raises_assertion_error(self):
+        with self.assertRaises(AssertionError):
+            warp_line((0, 0), (3, 4))
+
+    def test_horizontal_returns_list_of_tuples(self):
+        result = warp_line((0, 0), (2, 0))
+        self.assertIsInstance(result, list)
+        for item in result:
+            self.assertIsInstance(item, tuple)
+
+    def test_horizontal_y_is_constant(self):
+        result = warp_line((0, 7), (5, 7))
+        for pt in result:
+            self.assertEqual(pt[1], 7)
+
+    def test_vertical_x_is_constant(self):
+        result = warp_line((3, 0), (3, 5))
+        for pt in result:
+            self.assertEqual(pt[0], 3)
+
+    def test_horizontal_includes_both_endpoints(self):
+        result = warp_line((2, 7), (5, 7))
+        self.assertIn((2, 7), result)
+        self.assertIn((5, 7), result)
+
+    def test_horizontal_correct_length(self):
+        result = warp_line((0, 0), (4, 0))
+        self.assertEqual(len(result), 5)
+
+    def test_vertical_correct_length(self):
+        result = warp_line((0, 0), (0, 4))
+        self.assertEqual(len(result), 5)
+
+
+class TestGetCenterPoint(unittest.TestCase):
+
+    def test_formula_matches_expected(self):
+        tile_size = 32
+        for x, y in [(0, 0), (1, 1), (3, 5), (10, 7)]:
+            with self.subTest(x=x, y=y):
+                expected = (x * tile_size + tile_size // 2, y * tile_size + tile_size // 2)
+                self.assertEqual(get_center_point(x, y, tile_size), expected)
+
+    def test_origin_tile_size_32(self):
+        self.assertEqual(get_center_point(0, 0, 32), (16, 16))
+
+    def test_tile_1_1_tile_size_32(self):
+        self.assertEqual(get_center_point(1, 1, 32), (48, 48))
+
+    def test_tile_size_16(self):
+        self.assertEqual(get_center_point(0, 0, 16), (8, 8))
+
+    def test_returns_tuple_of_two(self):
+        result = get_center_point(1, 1, 32)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+
+    def test_large_coordinates(self):
+        self.assertEqual(get_center_point(100, 100, 32), (3216, 3216))
+
+
+class TestParseAnimatedSpriteSheet(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        pygame.init()
+        cls.screen = pygame.display.set_mode((256, 240))
+
+    @classmethod
+    def tearDownClass(cls):
+        pygame.quit()
+
+    def _make_surface(self, width, height):
+        """Create a real pygame Surface of the given dimensions."""
+        surf = pygame.Surface((width, height))
+        surf.fill((0, 0, 0))
+        return surf
+
+    def test_returns_four_lists(self):
+        tile_size = test_config['TILE_SIZE']
+        # A four-sided sprite sheet needs 8 columns of tile_size width.
+        # Width must be divisible by 128 and wide enough for (i+6)*tile_size rects.
+        # With tile_size=32: 8 * 32 = 256; 256 % 128 == 0 ✓
+        width = tile_size * 8
+        surf = self._make_surface(width, tile_size)
+        result = parse_animated_sprite_sheet(surf, test_config)
+        self.assertEqual(len(result), 4)
+        for lst in result:
+            self.assertIsInstance(lst, list)
+
+    def test_four_sided_sheet_all_lists_populated(self):
+        tile_size = test_config['TILE_SIZE']
+        # 8-column sheet (width % 128 == 0) → all four direction lists filled
+        width = tile_size * 8
+        surf = self._make_surface(width, tile_size)
+        facing_down, facing_left, facing_up, facing_right = parse_animated_sprite_sheet(surf, test_config)
+        self.assertEqual(len(facing_down), 2)
+        self.assertEqual(len(facing_left), 2)
+        self.assertEqual(len(facing_up), 2)
+        self.assertEqual(len(facing_right), 2)
+
+    def test_non_four_sided_sheet_has_only_facing_down(self):
+        tile_size = test_config['TILE_SIZE']
+        # Width not divisible by 128 (2 tiles wide) → only facing_down populated
+        width = tile_size * 2  # e.g. 64 — not divisible by 128
+        surf = self._make_surface(width, tile_size)
+        facing_down, facing_left, facing_up, facing_right = parse_animated_sprite_sheet(surf, test_config)
+        self.assertEqual(len(facing_down), 2)
+        self.assertEqual(len(facing_left), 0)
+        self.assertEqual(len(facing_up), 0)
+        self.assertEqual(len(facing_right), 0)
+
+    def test_facing_down_has_two_frames(self):
+        tile_size = test_config['TILE_SIZE']
+        width = tile_size * 8
+        surf = self._make_surface(width, tile_size)
+        facing_down, _, _, _ = parse_animated_sprite_sheet(surf, test_config)
+        self.assertEqual(len(facing_down), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_shops.py
+++ b/tests/test_shops.py
@@ -1,0 +1,118 @@
+import os
+import unittest
+
+os.environ['SDL_VIDEODRIVER'] = 'dummy'
+os.environ['SDL_AUDIODRIVER'] = 'dummy'
+
+import pygame
+
+from src.config.test_config import test_config
+from src.shops import ShopInventories
+
+VALID_ITEM_TYPES = {'weapon', 'armor', 'shield'}
+EXPECTED_KEYS = {'cost', 'type', 'menu_image'}
+
+
+class TestShopInventories(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        pygame.init()
+        cls.shops = ShopInventories(test_config)
+
+    @classmethod
+    def tearDownClass(cls):
+        pygame.quit()
+
+    def _all_inventories(self):
+        return [
+            self.shops.brecconary_weapons_store_inventory,
+            self.shops.rimuldar_weapons_store_inventory,
+            self.shops.garinham_weapons_store_inventory,
+            self.shops.kol_weapons_store_inventory,
+            self.shops.cantlin_weapons_store_north_inventory,
+            self.shops.cantlin_weapons_store_south_inventory,
+        ]
+
+    def test_instantiates_with_config(self):
+        shops = ShopInventories(test_config)
+        self.assertIsNotNone(shops)
+
+    def test_all_inventories_have_expected_keys(self):
+        for inventory in self._all_inventories():
+            for item_name, item_data in inventory.items():
+                with self.subTest(item=item_name):
+                    self.assertEqual(set(item_data.keys()), EXPECTED_KEYS)
+
+    def test_item_types_are_valid(self):
+        for inventory in self._all_inventories():
+            for item_name, item_data in inventory.items():
+                with self.subTest(item=item_name):
+                    self.assertIn(item_data['type'], VALID_ITEM_TYPES)
+
+    def test_costs_are_positive_integers(self):
+        for inventory in self._all_inventories():
+            for item_name, item_data in inventory.items():
+                with self.subTest(item=item_name):
+                    self.assertIsInstance(item_data['cost'], int)
+                    self.assertGreater(item_data['cost'], 0)
+
+    def test_menu_image_paths_are_strings(self):
+        for inventory in self._all_inventories():
+            for item_name, item_data in inventory.items():
+                with self.subTest(item=item_name):
+                    self.assertIsInstance(item_data['menu_image'], str)
+
+    # --- Specific item assertions ---
+
+    def test_bamboo_pole_cost_and_type(self):
+        item = self.shops.brecconary_weapons_store_inventory['Bamboo Pole']
+        self.assertEqual(item['cost'], 10)
+        self.assertEqual(item['type'], 'weapon')
+
+    def test_club_is_weapon(self):
+        item = self.shops.brecconary_weapons_store_inventory['Club']
+        self.assertEqual(item['cost'], 60)
+        self.assertEqual(item['type'], 'weapon')
+
+    def test_copper_sword_cost(self):
+        item = self.shops.brecconary_weapons_store_inventory['Copper Sword']
+        self.assertEqual(item['cost'], 180)
+        self.assertEqual(item['type'], 'weapon')
+
+    def test_clothes_is_armor(self):
+        item = self.shops.brecconary_weapons_store_inventory['Clothes']
+        self.assertEqual(item['cost'], 20)
+        self.assertEqual(item['type'], 'armor')
+
+    def test_small_shield_is_shield(self):
+        item = self.shops.brecconary_weapons_store_inventory['Small Shield']
+        self.assertEqual(item['cost'], 90)
+        self.assertEqual(item['type'], 'shield')
+
+    def test_broad_sword_in_rimuldar(self):
+        item = self.shops.rimuldar_weapons_store_inventory['Broad Sword']
+        self.assertEqual(item['cost'], 1500)
+        self.assertEqual(item['type'], 'weapon')
+
+    def test_magic_armor_is_shield_type(self):
+        # Despite its name, Magic Armor is categorised as 'shield' in the data
+        item = self.shops.rimuldar_weapons_store_inventory['Magic Armor']
+        self.assertEqual(item['cost'], 7700)
+        self.assertEqual(item['type'], 'shield')
+
+    def test_large_shield_in_garinham(self):
+        item = self.shops.garinham_weapons_store_inventory['Large Shield']
+        self.assertEqual(item['cost'], 800)
+        self.assertEqual(item['type'], 'shield')
+
+    def test_brecconary_inventory_not_empty(self):
+        self.assertGreater(len(self.shops.brecconary_weapons_store_inventory), 0)
+
+    def test_all_inventories_not_empty(self):
+        for inventory in self._all_inventories():
+            self.assertGreater(len(inventory), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Background

Three medium-effort improvements identified during the initial codebase survey.

## Changes

### 1. Spell enum (`src/spells.py`)

Added `Spell(str, Enum)` covering all player and enemy spells. Inheriting `str` means enum values work as dict keys and in `gettext` calls without casting — no call-site changes needed beyond the import.

Updated `enemy_spells.py`, `player_stats.py`, `game.py`, and `menu.py` to use `Spell` instead of bare string literals. Typos in spell names are now caught at import time rather than silently failing at runtime.

### 2. Missing tests

Three modules had zero test coverage:

- **`tests/test_maps_functions.py`** (20 tests) — `warp_line`, `get_center_point`, `parse_animated_sprite_sheet`
- **`tests/test_shops.py`** (15 tests) — `ShopInventories` structure, item types, costs, specific item spot-checks
- **`tests/test_drawer.py`** (30 tests) — pure functions (`replace_characters_with_underlying_tiles`, `get_surrounding_tile_values`, `convert_numeric_tile_list_to_unique_tile_values`, `get_fixed_character_underlying_tiles`) and `Drawer` methods via mocks

Total tests: 487 → 552 (+65)

### 3. mypy in CI (`.github/workflows/python-app.yml`)

Added a `mypy src --ignore-missing-imports` step. Running in warning-only mode (`|| true`) so it doesn't block the build — the 48 pre-existing type errors are now visible in CI output for future cleanup without blocking merges today.

## Testing Notes

- All 552 tests pass locally
- mypy surfaces 48 pre-existing errors (none introduced by this PR)