### PR TITLE
[fix-bugs] Fix 6 open bugs

### DIFF
--- a/src/drawer.py
+++ b/src/drawer.py
@@ -153,41 +153,47 @@ class Drawer:
                                                 tile_size * 3,
                                                 tile_size * 3)
         elif self.game_state.radiant_active:
-            # Light with radius of 2, expanding to 3...
-
-            # darkness_hole = darkness.subsurface((self.screen.get_width() / 2) - TILE_SIZE * 2, (self.screen.get_height() / 2) - (TILE_SIZE * 2.5),
-            #                                     TILE_SIZE * 5,
-            #                                     TILE_SIZE * 5)
-            # darkness.fill(BLACK)
-            # darkness_hole.fill(WHITE)
-            # darkness.set_colorkey(WHITE)
-            # self.screen.blit(darkness, (0, 0))
-            # Light with radius of 3
-            darkness_hole = darkness.subsurface((screen.get_width() / 2) - tile_size * 3,
-                                                (screen.get_height() / 2) - tile_size * 3.5,
-                                                tile_size * 7,
-                                                tile_size * 7)
-
             if self.game_state.radiant_start is None:
                 self.game_state.radiant_start = self.game_state.tiles_moved_total
                 self.sound.play_sound(self.directories.torch_sfx)
                 self.sound.play_sound(self.directories.torch_sfx)
+            tiles_elapsed = self.game_state.tiles_moved_total - self.game_state.radiant_start
+            if tiles_elapsed >= 200:
+                self.game_state.radiant_active = False
+                self.game_state.radiant_start = None
+                darkness_hole = darkness.subsurface((screen.get_width() / 2),
+                                                    (screen.get_height() / 2) - (tile_size / 2),
+                                                    tile_size, tile_size)
+            elif tiles_elapsed >= 140:
+                # shrinking back to radius 1
+                darkness_hole = darkness.subsurface((screen.get_width() / 2) - tile_size,
+                                                    (screen.get_height() / 2) - (tile_size * 1.5),
+                                                    tile_size * 3,
+                                                    tile_size * 3)
+            elif tiles_elapsed >= 80:
+                # shrinking to radius 2
+                darkness_hole = darkness.subsurface((screen.get_width() / 2) - tile_size * 2,
+                                                    (screen.get_height() / 2) - (tile_size * 2.5),
+                                                    tile_size * 5,
+                                                    tile_size * 5)
+            elif tiles_elapsed >= 40:
+                # full radius 3
+                darkness_hole = darkness.subsurface((screen.get_width() / 2) - tile_size * 3,
+                                                    (screen.get_height() / 2) - tile_size * 3.5,
+                                                    tile_size * 7,
+                                                    tile_size * 7)
+            elif tiles_elapsed >= 20:
+                # expanding to radius 2
+                darkness_hole = darkness.subsurface((screen.get_width() / 2) - tile_size * 2,
+                                                    (screen.get_height() / 2) - (tile_size * 2.5),
+                                                    tile_size * 5,
+                                                    tile_size * 5)
             else:
-                if self.game_state.tiles_moved_total - self.game_state.radiant_start >= 200:
-                    self.game_state.radiant_active = False
-                    self.game_state.radiant_start = None
-                elif self.game_state.tiles_moved_total - self.game_state.radiant_start >= 140:
-                    # Light with radius of 1
-                    darkness_hole = darkness.subsurface((screen.get_width() / 2) - tile_size,
-                                                        (screen.get_height() / 2) - (tile_size * 1.5),
-                                                        tile_size * 3,
-                                                        tile_size * 3)
-                elif self.game_state.tiles_moved_total - self.game_state.radiant_start >= 80:
-                    # Light with radius of 2
-                    darkness_hole = darkness.subsurface((screen.get_width() / 2) - tile_size * 2,
-                                                        (screen.get_height() / 2) - (tile_size * 2.5),
-                                                        tile_size * 5,
-                                                        tile_size * 5)
+                # initial radius 1
+                darkness_hole = darkness.subsurface((screen.get_width() / 2) - tile_size,
+                                                    (screen.get_height() / 2) - (tile_size * 1.5),
+                                                    tile_size * 3,
+                                                    tile_size * 3)
 
         else:
             darkness_hole = darkness.subsurface((screen.get_width() / 2),

--- a/src/game.py
+++ b/src/game.py
@@ -186,14 +186,15 @@ class Game:
             self.music_player.load_and_play_music(self.directories.intermezzo)
             self.show_main_menu_screen(self.screen)
         self.drawer.draw_all(self.screen, self.loop_count, self.big_map, self.current_map, self.player, self.cmd_menu,
-                             self.foreground_rects, self.enable_animate, self.camera, self.initial_dialog_enabled,
+                             self.foreground_rects, self.game_state.enable_animate, self.camera,
+                             self.initial_dialog_enabled,
                              self.events, self.skip_text, self.allow_save_prompt, self.game_state, self.torch_active,
                              self.color)
         while True:
             self.clock.tick(self.fps)
             self.get_events()
             self.drawer.draw_all(self.screen, self.loop_count, self.big_map, self.current_map, self.player,
-                                 self.cmd_menu, self.foreground_rects, self.enable_animate, self.camera,
+                                 self.cmd_menu, self.foreground_rects, self.game_state.enable_animate, self.camera,
                                  self.initial_dialog_enabled, self.events, self.skip_text, self.allow_save_prompt,
                                  self.game_state, self.torch_active, self.color)
             display.flip()
@@ -607,7 +608,8 @@ class Game:
         self.player.received_environment_damage = True
         flash_transparent_color(RED, self.screen, self.calculation, no_blit=self.game_state.config['NO_BLIT'])
         self.drawer.draw_all(self.screen, self.loop_count, self.big_map, self.current_map, self.player, self.cmd_menu,
-                             self.foreground_rects, self.enable_animate, self.camera, self.initial_dialog_enabled,
+                             self.foreground_rects, self.game_state.enable_animate, self.camera,
+                             self.initial_dialog_enabled,
                              self.events, self.skip_text, self.allow_save_prompt, self.game_state, self.torch_active,
                              self.color)
         display.flip()
@@ -665,6 +667,7 @@ class Game:
                 self.paused = False
             else:
                 self.game_state.pause_all_movement()
+                self.player.is_moving = False
                 self.paused = True
             print("I key pressed (Start button).")
 

--- a/src/menu.py
+++ b/src/menu.py
@@ -236,6 +236,7 @@ class CommandMenu(Menu):
                     if not skip_text and not disable_sound:
                         self.sound.play_sound(self.directories.menu_button_sfx)
                     display_current_line = False
+                    event.clear(KEYDOWN)
                 elif current_event.type == arrow_fade:
                     self.game.show_arrow = not self.game.show_arrow
 
@@ -746,16 +747,16 @@ class CommandMenu(Menu):
         currently_selected_item = list(list_counter.keys())[0]
         time.set_timer(arrow_fade, 530)
         while item_menu_displayed:
-            self.graphics.create_window(x=9, y=3, width=6, height=len(list_counter) + 1,
+            self.graphics.create_window(x=8, y=3, width=7, height=len(list_counter) + 1,
                                         window_background=self.directories.item_menu_background_lookup[
                                             len(list_counter)], screen=self.screen,
                                         color=self.color)
-            draw_text(list_string, tile_size * 10, tile_size * 4, self.screen, self.game.game_state.config,
+            draw_text(list_string, tile_size * 9, tile_size * 4, self.screen, self.game.game_state.config,
                       letter_by_letter=False)
-            self.graphics.blink_arrow(self.screen, x=tile_size * 9.5,
-                                      y=(tile_size + (current_arrow_position * tile_size / 7.5)) * 4, direction="right",
+            self.graphics.blink_arrow(self.screen, x=tile_size * 8.5,
+                                      y=tile_size * 4 + current_arrow_position * 17, direction="right",
                                       show_arrow=self.game.show_arrow, color=self.color)
-            display.update((9 * tile_size, 3 * tile_size, 6 * tile_size, (len(list_counter) + 1) * tile_size))
+            display.update((8 * tile_size, 3 * tile_size, 7 * tile_size, (len(list_counter) + 1) * tile_size))
             for current_event in event.get():
                 if any([current_event.type == KEYDOWN]):
                     if current_event.key in reject_keys:

--- a/src/text.py
+++ b/src/text.py
@@ -42,7 +42,7 @@ def draw_text(text: str, x: float, y: float, screen: Surface, config: dict, colo
                 if not config['NO_WAIT']:
                     time.wait(16)
                 if not disable_sound:
-                    if i % 2 == 0:
+                    if i % 3 == 0:
                         Sound(config).play_sound(directories.text_beep_sfx)
         else:
             if not config['NO_BLIT']:


### PR DESCRIPTION
## Summary

Fixes 6 open bugs in a single PR.

## Fixes

### #99 — NPC animation/movement during menu
`draw_all` was being passed `self.enable_animate` (a `Game` instance attribute hardcoded to `True`) instead of `self.game_state.enable_animate`. `pause_all_movement()` already correctly sets `game_state.enable_animate = False`, so NPCs now freeze when the command menu opens or the game is paused.

### #41 — Player movement not stopped when pause key pressed
Added `self.player.is_moving = False` when pausing, so the player doesn't coast through to the next tile mid-step before the pause takes effect.

### #97 — Mashing accept key during inn dialog restarts inn stay
After a dialog line is dismissed by a keypress, `event.clear(KEYDOWN)` now drains any queued KEYDOWN events so they don't immediately skip the next dialog line.

### #126 — Text beep SFX not timed correctly
Changed beep to fire every 3rd character instead of every 2nd, giving a ~50ms interval that better matches the NES cadence.

### #124 — Radiant light expands all at once
Restructured the radiant light logic: starts at radius 1, expands to radius 2 at tile 20, reaches full radius 3 at tile 40, holds to tile 80, then shrinks symmetrically. Previously the large hole rect was set unconditionally before the tile-threshold checks ran, so it always started at maximum radius.

### #123 — In-field spell menu spacing too narrow
- Widened the menu window from 6 to 7 tiles (shifted x from 9 to 8)
- Fixed the selection arrow y formula — was `(tile_size + position * tile_size / 7.5) * 4` giving ~8px per item; now `tile_size * 4 + position * 17` matching `draw_text`'s actual 17px line height

## Note

Issue #98 (fixed character ghosting) shares the same root cause as the roaming NPC ghosting fixed in PR #175 — both are resolved by the `last_rect` tile redraw coverage added there.

## Test plan

- [ ] `pytest` — all tests pass
- [ ] Open command menu in a town with roaming NPCs — NPCs should freeze while menu is open
- [ ] Press pause (I key) while walking — player should stop immediately
- [ ] Talk to innkeeper and mash accept — should not restart the inn stay
- [ ] Cast RADIANT in a dark dungeon — light should expand gradually 1→2→3 tiles then shrink back
- [ ] Open spell menu — items should be properly spaced with working selection arrow