### PR TITLE
[misc-fixes] Fix save/load completeness, NPC collision, roaming loop, dead fields

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -157,8 +157,6 @@ class Game:
                              self.tile_size)
         self.cmd_menu = CommandMenu(self)
 
-        self.enable_animate = True
-        self.enable_roaming = True
         self.clock = Clock()
         self.music_enabled = self.game_state.music_enabled
 
@@ -369,7 +367,7 @@ class Game:
         """
         Updates character positions and handles warp logic.
         """
-        if self.enable_roaming and self.current_map.roaming_characters:
+        if self.game_state.enable_roaming and self.current_map.roaming_characters:
             self.move_roaming_characters()
             self.update_roaming_character_positions()
         # currently can't process staircases right next to one another, need to fix
@@ -975,18 +973,19 @@ class Game:
                 if not roaming_character.is_moving:
                     roaming_character.direction_value = random.choice(list(map(int, Direction)))
                 else:  # character not moving and no input
-                    return
+                    continue
+                set_character_position(roaming_character, self.tile_size)
                 roaming_character.last_rect = roaming_character.rect.copy()
                 roaming_character.is_moving = True
             else:  # determine if character has reached new tile
                 if is_facing_medially(roaming_character):
                     if curr_pos_y % self.tile_size == 0:
                         roaming_character.is_moving, roaming_character.next_tile_checked = False, False
-                        return
+                        continue
                 elif is_facing_laterally(roaming_character):
                     if curr_pos_x % self.tile_size == 0:
                         roaming_character.is_moving, roaming_character.next_tile_checked = False, False
-                        return
+                        continue
             if is_facing_medially(roaming_character):
                 self.move_medially(roaming_character)
             elif is_facing_laterally(roaming_character):
@@ -999,8 +998,25 @@ class Game:
         """
         self.player.name = save_file["Name"]
         self.player.total_experience = save_file["Experience"]
+        self.player.level = self.player.get_level_by_experience()
+        self.player.update_stats_to_current_level()
         self.player.gold = save_file["Gold"]
+        self.player.current_hp = save_file.get("CurrentHP", self.player.max_hp)
+        self.player.current_mp = save_file.get("CurrentMP", self.player.max_mp)
+        self.player.weapon = save_file.get("Weapon", "")
+        self.player.armor = save_file.get("Armor", "")
+        self.player.shield = save_file.get("Shield", "")
+        self.player.update_attack_power()
+        self.player.update_defense_power()
         self.player.inventory = save_file["Inventory"]
+        self.player.spells = save_file.get("Spells", [])
+        saved_map = save_file.get("CurrentMap")
+        if saved_map and saved_map in map_lookup and saved_map != self.current_map.identifier:
+            next_map = map_lookup[saved_map](self.config)
+            destination = (save_file.get("PlayerRow"), save_file.get("PlayerColumn"))
+            if destination[0] is not None:
+                next_map.destination_coordinates = destination
+            self.map_mgr.change_map(next_map)
 
 
 def run():

--- a/src/map_manager.py
+++ b/src/map_manager.py
@@ -169,7 +169,7 @@ class MapManager:
             self.game.camera.set_camera_position((destination_coordinates[1], destination_coordinates[0]),
                                                  self.tile_size)
         self.drawer.draw_all(self.screen, self.game.loop_count, self.game.big_map, self.current_map, self.player,
-                             self.game.cmd_menu, self.game.foreground_rects, self.game.enable_animate,
+                             self.game.cmd_menu, self.game.foreground_rects, self.game_state.enable_animate,
                              self.game.camera, self.game.initial_dialog_enabled, self.game.events,
                              self.game.skip_text, self.game.allow_save_prompt, self.game_state,
                              self.game.torch_active, self.game.color)

--- a/src/menu.py
+++ b/src/menu.py
@@ -129,7 +129,16 @@ class CommandMenu(Menu):
             'Name': self.player.name,
             'Experience': self.player.total_experience,
             'Gold': self.player.gold,
-            'Inventory': self.player.inventory
+            'CurrentHP': self.player.current_hp,
+            'CurrentMP': self.player.current_mp,
+            'Weapon': self.player.weapon,
+            'Armor': self.player.armor,
+            'Shield': self.player.shield,
+            'Inventory': self.player.inventory,
+            'Spells': self.player.spells,
+            'CurrentMap': self.game.current_map.identifier,
+            'PlayerRow': self.player.row,
+            'PlayerColumn': self.player.column,
         }
         json_object = json.dumps(save_dict, indent=4)
         with open(join(self.directories.save_dir, f'save_slot_{self.player.adventure_log}.json'),

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -377,8 +377,8 @@ class TestGame(TestCase):
         with patch.object(CommandMenu, 'window_drop_up_effect', return_value=None) as mock_window_drop_up_effect:
             self.assertFalse(self.game.cmd_menu.launch_signaled)
             self.game.unlaunch_menu(self.game.cmd_menu)
-            self.assertTrue(self.game.enable_animate)
-            self.assertTrue(self.game.enable_roaming)
+            self.assertTrue(self.game.game_state.enable_animate)
+            self.assertTrue(self.game.game_state.enable_roaming)
             self.assertTrue(self.game.game_state.enable_movement)
             self.assertFalse(self.game.cmd_menu.menu.is_enabled())
         mock_window_drop_up_effect.assert_called_with(6, 1, 8, 5)
@@ -461,7 +461,7 @@ class TestGame(TestCase):
         self.assertEqual('BRICK', self.game.player.current_tile)
         self.assertEqual((0, -1), self.game.player.next_coordinates)
         self.assertEqual((1, -1), self.game.player.next_next_coordinates)
-        self.game.enable_roaming = True
+        self.game.game_state.enable_roaming = True
         self.game.player.row = 10
         self.game.player.column = 13
         self.game.current_map.staircases = {
@@ -472,7 +472,7 @@ class TestGame(TestCase):
     def test_draw_all(self):
         self.game.drawer.draw_all(self.game.screen, self.game.loop_count, self.game.big_map, self.game.current_map,
                                   self.game.player, self.game.cmd_menu, self.game.foreground_rects,
-                                  self.game.enable_animate, self.game.camera, self.game.initial_dialog_enabled,
+                                  self.game.game_state.enable_animate, self.game.camera, self.game.initial_dialog_enabled,
                                   self.game.events, self.game.skip_text, self.game.allow_save_prompt,
                                   self.game.game_state, self.game.torch_active, self.game.color)
         self.assertTrue(self.game.drawer.not_moving_time_start)


### PR DESCRIPTION
## Summary

Five self-identified improvements across save/load, NPC behavior, and code hygiene.

## Changes

### 1. Save/load completeness
`save()` previously only persisted name, experience, gold, and inventory. A loaded game would start the player back at level 1 in Tantegel with no equipment, no spells, and full HP regardless of their state when they saved.

Now saves and restores: `current_hp`, `current_mp`, `weapon`, `armor`, `shield`, `spells`, `current_map`, `player_row`, `player_column`. On load, level and stats are recalculated from experience, attack/defense power is recomputed from equipment, and `change_map` is called if the saved map differs from the starting map. Old save files without the new keys fall back to sensible defaults (`get()` with fallbacks).

### 2. NPC wall collision
Roaming NPCs could walk through walls and each other. Root cause: `move()` calls `get_next_tile_identifier(character.column, character.row, ...)` to check impassability, but `column`/`row` was stale (last set at spawn) because `set_character_position` only runs after a move completes. Fix: call `set_character_position` at the moment a roaming character starts a new move, so `column`/`row` reflects the current tile-aligned position before the collision check runs.

### 3. Roaming character loop early-return (#5)
All three `return` statements inside `move_roaming_characters` changed to `continue`. Previously, finishing or starting a move for one character would `return` out of the entire loop, leaving all subsequent characters unprocessed that frame.

### 4. Dead `enable_animate` / `enable_roaming` fields on `Game`
`Game.enable_animate` and `Game.enable_roaming` were set to `True` at init and never changed — the canonical state lived on `game_state` all along. Removed both fields and updated the one remaining stale read in `map_manager.py` and three test references to use `game_state` directly.

## Test plan

- [ ] `pytest` — all 552 tests pass
- [ ] Save in a dungeon with equipment and spells, quit and reload — player should appear in the same map at the same position with the same equipment/HP/spells
- [ ] Watch roaming NPCs in Brecconary or Garinham — they should not walk through walls or each other
- [ ] Verify multiple roaming NPCs all move each second (not just the first one)