### PR TITLE
[fix-mypy-errors] Fix all 49 mypy type errors across 13 files

### DIFF
--- a/data/text/dialog_lookup_table.py
+++ b/data/text/dialog_lookup_table.py
@@ -237,7 +237,9 @@ class DialogLookup:
         }
 
         for map_dict in self.lookup_table.values():
+            assert isinstance(map_dict, dict)
             for character_identifier, character_dict in map_dict.items():
+                assert isinstance(character_dict, dict)
                 character_dict['dialog_character'] = character_identifier
 
     def take_to_castle_confirmation_prompt(self):

--- a/src/calculation.py
+++ b/src/calculation.py
@@ -15,7 +15,7 @@ class Calculation:
 
     @staticmethod
     def get_next_tile_identifier(character_column: int, character_row: int, direction_value: int, current_map,
-                                 offset: int = 1) -> str:
+                                 offset: int = 1) -> str | None:
         """
         Retrieve the identifier (human-readable name) of the next tile in front of a particular character.
         :type character_column: int
@@ -35,6 +35,7 @@ class Calculation:
             return get_tile_id_by_coordinates(character_column - offset, character_row, current_map)
         elif direction_value == Direction.RIGHT.value:
             return get_tile_id_by_coordinates(character_column + offset, character_row, current_map)
+        return None
 
     def convert_to_frames_since_start_time(self, start_time):
         return self.convert_to_frames(get_ticks() - start_time)
@@ -45,7 +46,7 @@ class Calculation:
         return column - 51,  row - 50
 
 
-def get_tile_id_by_coordinates(column: int, row: int, game_map) -> str:
+def get_tile_id_by_coordinates(column: int, row: int, game_map) -> str | None:
     """
     Retrieve the tile name from the coordinates of the tile on the map.
     :param column: The column of the tile.
@@ -54,3 +55,4 @@ def get_tile_id_by_coordinates(column: int, row: int, game_map) -> str:
     """
     if row < len(game_map.layout) and column < len(game_map.layout[0]):
         return game_map.get_tile_by_value(game_map.layout[row][column])
+    return None

--- a/src/common.py
+++ b/src/common.py
@@ -20,8 +20,8 @@ def find_file(name, path):
 
 # Images
 
-_image_library = {}
-_scaled_image_library = {}  # Cache for scaled images
+_image_library: dict[str, object] = {}
+_scaled_image_library: dict[tuple, object] = {}  # Cache for scaled images
 
 
 # Characters

--- a/src/config/base_config.py
+++ b/src/config/base_config.py
@@ -2,6 +2,7 @@ import locale
 
 SCALE = 2
 LANGUAGE, ENCODING = locale.getlocale()
+LANGUAGE = LANGUAGE or "en_US"
 
 base_config = {
     "START_MAP": "TantegelThroneRoom",

--- a/src/drawer.py
+++ b/src/drawer.py
@@ -256,7 +256,7 @@ class Drawer:
 
             # tile_types_to_draw = list(filter(lambda x: not self.is_impassable(x), tile_types_to_draw))
 
-        group_to_draw = Group()
+        group_to_draw: Group = Group()
         camera_screen_rect = Rect(player.rect.x - tile_size * 8, player.rect.y - tile_size * 7,
                                   screen.get_width(), screen.get_height())
         double_camera_screen_rect = camera_screen_rect.inflate(camera_screen_rect.width * 0.25,

--- a/src/game.py
+++ b/src/game.py
@@ -471,12 +471,6 @@ class Game:
     def enemy_attack_message(self, enemy):
         self.battle_ctrl.enemy_attack_message(enemy)
 
-    def handle_near_tantegel_fight_modifier(self):
-        return self.battle_ctrl.handle_near_tantegel_fight_modifier()
-
-    def get_random_integer_by_tile(self):
-        return self.battle_ctrl.get_random_integer_by_tile()
-
     def receive_damage(self, attack_damage):
         # God mode or invulnerable: take no damage
         if self.player.god_mode or self.invulnerable:
@@ -902,7 +896,7 @@ class Game:
                                                                                 character.direction_value,
                                                                                 self.current_map, offset=2)
 
-    def character_in_path(self, character: RoamingCharacter | FixedCharacter) -> bool:
+    def character_in_path(self, character: Player | RoamingCharacter | FixedCharacter) -> bool:
         fixed_character_locations = [(fixed_character.column, fixed_character.row) for fixed_character in
                                      self.current_map.fixed_characters]
         roaming_character_locations = [(roaming_character.column, roaming_character.row) for roaming_character in
@@ -911,16 +905,17 @@ class Game:
         return next_coordinates in fixed_character_locations + roaming_character_locations + [
             (self.player.column, self.player.row)]
 
-    def get_next_coordinates(self, character_column: int, character_row: int, direction: int) -> tuple:
+    def get_next_coordinates(self, character_column: int, character_row: int, direction: int) -> tuple | None:
         if character_row < len(self.current_map.layout) and character_column < len(self.current_map.layout[0]):
             if direction == Direction.UP.value:
                 return character_column, character_row - 1
             elif direction == Direction.DOWN.value:
-                return character_column, character_row + 1,
+                return character_column, character_row + 1
             elif direction == Direction.LEFT.value:
                 return character_column - 1, character_row
             elif direction == Direction.RIGHT.value:
                 return character_column + 1, character_row
+        return None
 
     def is_impassable(self, tile: str) -> bool:
         """

--- a/src/game_functions.py
+++ b/src/game_functions.py
@@ -32,7 +32,7 @@ class GameFunctions:
         self.graphics = Graphics(config)  # Add graphics for caching
 
     def main_menu_selection(self, blink_start: int, screen, unselected_image: str, selected_image: str,
-                            other_selected_images: List[str] = None, no_blit: bool = False) -> int:
+                            other_selected_images: List[str] | None = None, no_blit: bool = False) -> int:
         # TODO: Merge with open_store_inventory() if possible
         current_item_index = 0
         all_selected_images = [selected_image] + (other_selected_images or [])
@@ -69,7 +69,7 @@ def set_character_position(character, tile_size: int):
     character.column, character.row = character.rect.x // tile_size, character.rect.y // tile_size
 
 
-def get_next_coordinates(character_column: int, character_row: int, direction: int, offset_from_character: int = 1) -> Tuple[int, int]:
+def get_next_coordinates(character_column: int, character_row: int, direction: int, offset_from_character: int = 1) -> Tuple[int, int] | None:
     match direction:
         case Direction.UP.value:
             return character_row - offset_from_character, character_column
@@ -79,6 +79,7 @@ def get_next_coordinates(character_column: int, character_row: int, direction: i
             return character_row, character_column - offset_from_character
         case Direction.RIGHT.value:
             return character_row, character_column + offset_from_character
+    return None
 
 
 def get_surrounding_rect(character, tile_size: int) -> Rect:

--- a/src/items.py
+++ b/src/items.py
@@ -1,4 +1,5 @@
 import random
+from typing import Dict, Tuple
 
 weapons = {
     "Bamboo Pole": {'offense': 2, 'cost': 10, 'found': ("Brecconary", "Cantlin")},
@@ -33,7 +34,7 @@ shields = {
     "Silver Shield": {'defense': 20, 'cost': 14_800, 'sold': ("Cantlin",)},
 }
 
-treasure = {
+treasure: Dict[str, Dict[Tuple[int, int], Dict[str, object]]] = {
     'TantegelThroneRoom': {(7, 17): {'item': 'Magic Key'},
                            (10, 14): {'item': "GOLD", 'amount': 120},
                            (10, 15): {'item': "Torch"}},

--- a/src/maps.py
+++ b/src/maps.py
@@ -176,9 +176,10 @@ class DragonWarriorMap:
     def map_npc(self, identifier, direction, underlying_tile, image_path, four_sided, coordinates,
                 is_roaming) -> None:
         sheet = self.graphics.get_image(image_path)
-        character_sprites = LayeredDirty()
+        character_sprites: LayeredDirty = LayeredDirty()
         sheet = scale(sheet, (sheet.get_width() * self.scale, sheet.get_height() * self.scale))
         images = parse_animated_sprite_sheet(sheet, self.config)
+        character: RoamingCharacter | FixedCharacter | AnimatedSprite
         if four_sided:
             if is_roaming:
                 character = RoamingCharacter(self.center_pt, direction, images, identifier)
@@ -190,7 +191,7 @@ class DragonWarriorMap:
                 self.fixed_characters.append(character)
         else:
             character = AnimatedSprite(self.center_pt, Direction.DOWN.value, images, identifier)
-            character.row, character.column = coordinates
+            character.row, character.column = coordinates  # type: ignore[attr-defined]
             self.fixed_characters.append(character)
         character_sprites.add(character)
         tile_value = \
@@ -265,7 +266,7 @@ class DragonWarriorMap:
 
     def create_town_gates(self, north_gate=None, east_gate=None, west_gate=None, south_gate=None) -> None:
         alefgard_up_staircase = {'map': 'Alefgard', 'stair_direction': 'up'}
-        staircases_keys = []
+        staircases_keys: list[tuple] = []
         staircases_keys += north_gate if north_gate is not None else []
         staircases_keys += east_gate if east_gate is not None else []
         staircases_keys += west_gate if west_gate is not None else []

--- a/src/menu.py
+++ b/src/menu.py
@@ -5,7 +5,7 @@ from collections import Counter
 from os.path import join
 
 from src.spells import Spell
-from typing import Tuple, List
+from typing import Any, Callable, Tuple, List
 
 import pygame_menu
 from pygame import Surface, display, KEYDOWN, Rect, event, K_UP, K_DOWN, K_w, K_s, USEREVENT, time, mixer
@@ -175,7 +175,7 @@ class CommandMenu(Menu):
         self.show_line_in_dialog_box(line, add_quotes=False, skip_text=True, hide_arrow=True, disable_sound=True)
 
     def show_line_in_dialog_box(self, line: str | functools.partial, add_quotes: bool = True,
-                                temp_text_start: int = None, skip_text: bool = False, hide_arrow=False,
+                                temp_text_start: int | None = None, skip_text: bool = False, hide_arrow=False,
                                 disable_sound=False, letter_by_letter=True):
         """Shows a single line in a dialog box.
         :param hide_arrow: Whether to show the continuation arrow
@@ -306,7 +306,7 @@ class CommandMenu(Menu):
             # if the map is dark, drawing all the tiles to the screen basically creates an exploit that shows the map tiles lit up,
             # even without a torch or radiant
             # might be good to revisit this later with just a black background?
-            group_to_draw = Group()
+            group_to_draw: Group = Group()
             for tile, tile_dict in self.current_map.floor_tile_key.items():
                 if tile in self.current_map.tile_types_in_current_map and tile_dict.get('group'):
                     for tile_sprite in tile_dict['group']:
@@ -707,6 +707,7 @@ class CommandMenu(Menu):
         :param menu_name: The name of the menu to display.
         """
         tile_size = self.game.game_state.config['TILE_SIZE']
+        function_dict: dict[Any, Any] = {}
         if menu_name == 'inventory':
             list_counter = Counter(self.player.inventory)
             list_string = ""
@@ -832,7 +833,7 @@ class CommandMenu(Menu):
         if self.player.current_tile == 'TREASURE_BOX':
             treasure_info = treasure[self.map_name].get((self.player.row, self.player.column))
             if treasure_info:
-                item_name = treasure_info['item']
+                item_name = str(treasure_info['item']) if treasure_info.get('item') is not None else None
                 self.sound.play_sound(self.directories.menu_button_sfx)
                 if item_name:
                     if item_name == 'GOLD':

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -73,8 +73,8 @@ class Player(AnimatedSprite):
 
         self.points_to_next_level = self.get_points_to_next_level()
 
-        self.spells = []
-        self.inventory = []
+        self.spells: list[str] = []
+        self.inventory: list[str] = []
         self.god_mode = god_mode
         if god_mode:
             self.total_experience = 65536

--- a/src/player/player_stats.py
+++ b/src/player/player_stats.py
@@ -1,4 +1,5 @@
 from math import floor
+from typing import cast
 
 from src.spells import Spell
 
@@ -41,7 +42,7 @@ letter_calculations = {
     15: ("f", "v", "L", "("),
 }
 
-levels_list = {
+levels_list: dict[int, dict[str, int | Spell | None]] = {
     1: {'total_exp': 0, 'strength': 4, 'agility': 4, 'max_hp': 15, 'max_mp': 0, 'spell': None},
     2: {'total_exp': 7, 'strength': 5, 'agility': 4, 'max_hp': 22, 'max_mp': 0, 'spell': None},
     3: {'total_exp': 23, 'strength': 7, 'agility': 6, 'max_hp': 24, 'max_mp': 5, 'spell': Spell.HEAL},
@@ -102,8 +103,8 @@ def get_bonus(name_score: int) -> int:
     return (name_score // 4) % 4
 
 
-def stat_calc(bonus: int, base: int) -> int:
-    return floor(base * .9) + bonus
+def stat_calc(bonus: int, base: int | None) -> int:
+    return floor((base or 0) * .9) + bonus
 
 
 def determine_penalized_stats(name_score: int) -> tuple[str, ...]:
@@ -126,4 +127,4 @@ def apply_transformation_to_levels_list(name: str) -> None:
         for stat in penalized_stats:
             if stat == 'max_mp' and i <= 2:
                 continue
-            levels_list[i][stat] = stat_calc(bonus, levels_list[i][stat])
+            levels_list[i][stat] = stat_calc(bonus, cast(int | None, levels_list[i][stat]))

--- a/src/sound.py
+++ b/src/sound.py
@@ -7,7 +7,7 @@ from src.directories import Directories
 
 # Sound
 
-_sound_library = {}
+_sound_library: dict[str, object] = {}
 
 
 class Sound:

--- a/src/sprites/roaming_character.py
+++ b/src/sprites/roaming_character.py
@@ -12,5 +12,6 @@ class RoamingCharacter(AnimatedSprite):
         self.previous_tile = None
         self.current_tile = None
         self.next_tile_id = None
+        self.next_next_tile_id = None
         self.next_tile_checked = False
         self.last_rect = None

--- a/src/text.py
+++ b/src/text.py
@@ -20,7 +20,7 @@ class DialogBoxWrapper(textwrap.TextWrapper):
 
 def draw_text(text: str, x: float, y: float, screen: Surface, config: dict, color: tuple = WHITE, size: int = 16,
               text_wrap_length: int = WRAP_LENGTH, alignment: str = 'left', letter_by_letter: bool = True,
-              disable_sound: bool = False, font_name: str = None) -> str:
+              disable_sound: bool = False, font_name: str | None = None) -> str | None:
     # 34 is the maximum characters on the screen at a time.
     # 21? appears to be the actual max in the original game
     # chunks = [text[i:i + n] for i in range(0, len(text), n)]
@@ -51,6 +51,7 @@ def draw_text(text: str, x: float, y: float, screen: Surface, config: dict, colo
         y += 17
         if chunk == chunks[len(chunks) - 1]:
             return chunk
+    return None
 
 
 def set_font_by_ascii_chars(chunks, size, font_name, directories):


### PR DESCRIPTION
## Summary

- Add proper type annotations throughout the codebase (`str | None`, `int | None`, `dict[...]`, `list[...]`)
- Fix missing return statements in `calculation.py` and `game.py`
- Remove duplicate method stubs (`handle_near_tantegel_fight_modifier`, `get_random_integer_by_tile`) in `game.py` that caused `no-redef` errors
- Fix `treasure` dict type in `items.py` so `in` / `del` operations type-check correctly
- Fix `function_dict` in `menu.py` — uses `dict[Any, Any]` since the inventory and spell branches have incompatible key/value types
- Add `next_next_tile_id = None` to `RoamingCharacter` to match the `Player` interface used in `check_next_tile`
- Widen `character_in_path` signature to accept `Player | RoamingCharacter | FixedCharacter`
- Use `# type: ignore[attr-defined]` for the intentional dynamic `row`/`column` assignment on bare `AnimatedSprite` in `maps.py`
- Add `assert isinstance()` guards in `dialog_lookup_table.py` to help mypy narrow nested dict types
- Add `get_next_coordinates` return type fix in `game.py` (`tuple | None` with explicit `return None`)

## Test plan

- [x] `mypy src --ignore-missing-imports --exclude 'src/map_layouts.py'` reports zero errors
- [x] All 552 unit tests pass (`pytest` — 552 passed, 1210 subtests passed)